### PR TITLE
zmq_msg_t handling

### DIFF
--- a/zmq_test.go
+++ b/zmq_test.go
@@ -38,6 +38,13 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestCreateDestroyContext(t *testing.T) {
+   c := Context()
+   c.Close()
+   c = Context()
+   c.Close()
+}
+
 func TestBindToLoopBack(t *testing.T) {
 	c := Context()
 	defer c.Close()
@@ -45,6 +52,19 @@ func TestBindToLoopBack(t *testing.T) {
 	defer s.Close()
 	if rc := s.Bind(ADDRESS); rc != nil {
 		t.Errorf("Failed to bind to %s; %s", ADDRESS, rc.String())
+	}
+}
+
+func TestSetSockOptString(t *testing.T) {
+	c := Context()
+	defer c.Close()
+	s := c.Socket(SUB)
+	defer s.Close()
+	if rc := s.Bind(ADDRESS); rc != nil {
+		t.Errorf("Failed to bind to %s; %s", ADDRESS, rc.String())
+	}
+	if rc := s.SetSockOptString(SUBSCRIBE, "TEST"); rc != nil {
+		t.Errorf("Failed to subscribe; %v", rc)
 	}
 }
 


### PR DESCRIPTION
Hi,

Your ZeroMQ binding looks really nice. Thanks for making it available. 

I made a couple of changes which you might like. The zmq_msg_t class can allocate a buffer that it manages, so you don't have to do explicit allocation and management if you are going to copy anyway. It also handles zero length messages in and out.

Jim
