### PR TITLE
ZMQ 2.1 compatibility with build flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Install gozmq with::
 
   go get github.com/alecthomas/gozmq
 
+If you're using ZeroMQ 2.1.x, install with::
+
+  go get -tags 'zmq_2_1' github.com/alecthomas/gozmq
+
 If that doesn't work you might need to checkout the source and play with the
 CGO_LDFLAGS and CGO_CFLAGS in the Makefile::
 

--- a/zmq.go
+++ b/zmq.go
@@ -117,8 +117,6 @@ var (
 	RECONNECT_IVL     = IntSocketOption(C.ZMQ_RECONNECT_IVL)
 	RECONNECT_IVL_MAX = IntSocketOption(C.ZMQ_RECONNECT_IVL_MAX)
 	BACKLOG           = IntSocketOption(C.ZMQ_BACKLOG)
-	RCVTIMEO          = IntSocketOption(C.ZMQ_RCVTIMEO)
-	SNDTIMEO          = IntSocketOption(C.ZMQ_SNDTIMEO)
 
 	// Send/recv options
 	NOBLOCK = SendRecvOption(C.ZMQ_NOBLOCK)

--- a/zmq_2_2.go
+++ b/zmq_2_2.go
@@ -1,0 +1,29 @@
+// +build !zmq_2_1
+
+/*
+  Copyright 2010-2012 Alec Thomas
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package gozmq
+
+/*
+#include <zmq.h>
+*/
+import "C"
+
+var (
+	RCVTIMEO = IntSocketOption(C.ZMQ_RCVTIMEO)
+	SNDTIMEO = IntSocketOption(C.ZMQ_SNDTIMEO)
+)


### PR DESCRIPTION
I was thinking about ZMQ 2.1 compatibility and thought accepting a build tag to indicate 2.1 will work well.
