### PR TITLE
ZMQ_FAIL_UNROUTABLE was renamed in v3.2.1-RC2

### DIFF
--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -34,7 +34,7 @@ var (
 
 	// TODO Not documented in the man page...
 	//LAST_ENDPOINT       = UInt64SocketOption(C.ZMQ_LAST_ENDPOINT)
-	FAIL_UNROUTABLE     = BoolSocketOption(C.ZMQ_FAIL_UNROUTABLE)
+	ROUTER_MANDATORY     = BoolSocketOption(C.ZMQ_ROUTER_MANDATORY)
 	TCP_KEEPALIVE       = IntSocketOption(C.ZMQ_TCP_KEEPALIVE)
 	TCP_KEEPALIVE_CNT   = IntSocketOption(C.ZMQ_TCP_KEEPALIVE_CNT)
 	TCP_KEEPALIVE_IDLE  = IntSocketOption(C.ZMQ_TCP_KEEPALIVE_IDLE)


### PR DESCRIPTION
v3.2.1-RC2 was released yesterday. 

ZMQ_FAIL_UNROUTABLE got renamed (twice) to ZMQ_ROUTER_MANDATORY.

without this, build fails:

```
# github.com/alecthomas/gozmq
1: error: 'ZMQ_FAIL_UNROUTABLE' undeclared (first use in this function)
1: note: each undeclared identifier is reported only once for each function it appears in
```

ref:
https://github.com/zeromq/libzmq/pull/383
https://github.com/zeromq/libzmq/pull/436
