### PR TITLE
Fix 3.x migration bug with zmq_sendmsg return value.

### DIFF
--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -65,7 +65,7 @@ func (s *zmqSocket) Send(data []byte, flags SendRecvOption) error {
 		C.memcpy(unsafe.Pointer(C.zmq_msg_data(&m)), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
 	}
 
-	if C.zmq_sendmsg(s.s, &m, C.int(flags)) != 0 {
+	if C.zmq_sendmsg(s.s, &m, C.int(flags)) == -1 {
 		// zmq_send did not take ownership, free message
 		C.zmq_msg_close(&m)
 		return errno()


### PR DESCRIPTION
Just like #39 but with zmq_sendmsg instead of zmq_msg_recv.
