### PR TITLE
Context Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ var (
 	// Additional ZMQ errors
 	ENOTSOCK       error = zmqErrno(C.ENOTSOCK)
 	EFSM           error = zmqErrno(C.EFSM)
+	EINVAL         error = zmqErrno(C.EINVAL)
 	ENOCOMPATPROTO error = zmqErrno(C.ENOCOMPATPROTO)
 	ETERM          error = zmqErrno(C.ETERM)
 	EMTHREAD       error = zmqErrno(C.EMTHREAD)
@@ -320,12 +321,25 @@ should generally be one context per application.
 ```go
 func NewContext() (*Context, error)
 ```
-Create a new context. void *zmq_init (int io_threads);
+Create a new context.
 
 #### func (*Context) Close
 
 ```go
 func (c *Context) Close()
+```
+
+#### func (*Context) IOThreads
+
+```go
+func (c *Context) IOThreads() (int, error)
+```
+Get a context option.
+
+#### func (*Context) MaxSockets
+
+```go
+func (c *Context) MaxSockets() (int, error)
 ```
 
 #### func (*Context) NewSocket
@@ -334,6 +348,19 @@ func (c *Context) Close()
 func (c *Context) NewSocket(t SocketType) (*Socket, error)
 ```
 Create a new socket. void *zmq_socket (void *context, int type);
+
+#### func (*Context) SetIOThreads
+
+```go
+func (c *Context) SetIOThreads(value int) error
+```
+Set a context option.
+
+#### func (*Context) SetMaxSockets
+
+```go
+func (c *Context) SetMaxSockets(value int) error
+```
 
 #### type DeviceType
 

--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -39,6 +39,17 @@ const (
 	DONTWAIT = NOBLOCK
 )
 
+// Get a context option.
+func (c *Context) IOThreads() (int, error) {
+	return c.iothreads, nil
+}
+
+// Set a context option.
+func (c *Context) SetIOThreads(value int) error {
+	c.iothreads = value
+	return nil
+}
+
 // Send a message to the socket.
 // int zmq_send (void *s, zmq_msg_t *msg, int flags);
 func (s *Socket) Send(data []byte, flags SendRecvOption) error {

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -54,6 +54,48 @@ const (
 	NOBLOCK = DONTWAIT
 )
 
+// Get a context option.
+// int zmq_ctx_get (void *c, int);
+func (c *Context) get(option C.int) (int, error) {
+	if c.init(); c.err != nil {
+		return -1, c.err
+	}
+	var value C.int
+	var err error
+	if value, err = C.zmq_ctx_get(c.c, option); err != nil {
+		return -1, casterr(err)
+	}
+	return int(value), nil
+}
+
+// Set a context option.
+// int zmq_ctx_set (void *c, int, int);
+func (c *Context) set(option C.int, value int) error {
+	if c.init(); c.err != nil {
+		return c.err
+	}
+	if rc, err := C.zmq_ctx_set(c.c, option, C.int(value)); rc == -1 {
+		return casterr(err)
+	}
+	return nil
+}
+
+func (c *Context) IOThreads() (int, error) {
+	return c.get(C.ZMQ_IO_THREADS)
+}
+
+func (c *Context) MaxSockets() (int, error) {
+	return c.get(C.ZMQ_MAX_SOCKETS)
+}
+
+func (c *Context) SetIOThreads(value int) error {
+	return c.set(C.ZMQ_IO_THREADS, value)
+}
+
+func (c *Context) SetMaxSockets(value int) error {
+	return c.set(C.ZMQ_MAX_SOCKETS, value)
+}
+
 // Send a message to the socket.
 // int zmq_send (void *s, zmq_msg_t *msg, int flags);
 func (s *Socket) Send(data []byte, flags SendRecvOption) error {

--- a/zmq_test.go
+++ b/zmq_test.go
@@ -118,6 +118,29 @@ func TestCreateDestroyContext(t *testing.T) {
 	c.Close()
 }
 
+func TestContext_IOThreads(t *testing.T) {
+	c, _ := NewContext()
+	defer c.Close()
+	if iothreads, err := c.IOThreads(); err != nil {
+		t.Fatalf("Failed to get IO_THREADS: %s", err.Error())
+	} else if iothreads != 1 {
+		t.Fatalf("Got IO_THREADS = %s", iothreads)
+	}
+}
+
+func TestContext_SetIOThreads(t *testing.T) {
+	c, _ := NewContext()
+	defer c.Close()
+	if err := c.SetIOThreads(2); err != nil {
+		t.Fatalf("Failed to set IO_THREADS: %s", err.Error())
+	}
+	if iothreads, err := c.IOThreads(); err != nil {
+		t.Fatalf("Failed to get IO_THREADS: %s", err.Error())
+	} else if iothreads != 2 {
+		t.Fatalf("Got IO_THREADS = %s", iothreads)
+	}
+}
+
 func TestSocket_Connect(t *testing.T) {
 	c, _ := NewContext()
 	defer c.Close()


### PR DESCRIPTION
Since libzmq 2.x only lets iothreads be specified as an argument to the context constructor while libzmq 3.x supports a general purpose API for setting context options, I took a tip from czmq and delayed actual context construction until it's required and followed the pattern already used in gozmq for socket options to support both 2.x and 3.x.  The result passes tests on both 2.2.0 and 3.2.2.
