### PR TITLE
Making gozmq compile for 0MQ 3.2

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -72,7 +72,7 @@ type BoolSocketOption int
 type MessageOption int
 type SendRecvOption int
 
-var (
+const (
 	// NewSocket types
 	PAIR   = SocketType(C.ZMQ_PAIR)
 	PUB    = SocketType(C.ZMQ_PUB)
@@ -126,7 +126,7 @@ var (
 
 type PollEvents C.short
 
-var (
+const (
 	POLLIN  = PollEvents(C.ZMQ_POLLIN)
 	POLLOUT = PollEvents(C.ZMQ_POLLOUT)
 	POLLERR = PollEvents(C.ZMQ_POLLERR)
@@ -134,7 +134,7 @@ var (
 
 type DeviceType int
 
-var (
+const (
 	STREAMER  = DeviceType(C.ZMQ_STREAMER)
 	FORWARDER = DeviceType(C.ZMQ_FORWARDER)
 	QUEUE     = DeviceType(C.ZMQ_QUEUE)
@@ -173,24 +173,26 @@ type zmqContext struct {
 }
 
 // Create a new context.
-// void *zmq_init (int io_threads);
+// 0MQ 2.x: void *zmq_init (int io_threads);
+// 0MQ 3.x: void *zmq_ctx_new(void);
 func NewContext() (Context, error) {
-	// TODO Pass something useful here. Number of cores?
 	// C.NULL is correct but causes a runtime failure on darwin at present
-	if c := C.zmq_init(1); c != nil /*C.NULL*/ {
+	if c := createZmqContext(); c != nil /*C.NULL*/ {
 		return &zmqContext{c}, nil
 	}
 	return nil, errno()
 }
 
-// int zmq_term (void *context);
 func (c *zmqContext) destroy() {
 	// Will this get called without being added by runtime.SetFinalizer()?
 	c.Close()
 }
 
+// Destroy context.
+// 0MQ 2.x: int zmq_term (void *context);
+// 0MQ 3.x: int zmq_ctx_destroy (void *context);
 func (c *zmqContext) Close() {
-	C.zmq_term(c.c)
+	destroyZmqContext(c.c)
 }
 
 // Create a new socket.

--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -36,6 +36,14 @@ var (
 	NOBLOCK           = SendRecvOption(C.ZMQ_NOBLOCK)
 )
 
+func createZmqContext() unsafe.Pointer {
+	return C.zmq_init(1)
+}
+
+func destroyZmqContext(c unsafe.Pointer) {
+	C.zmq_term(c)
+}
+
 // Send a message to the socket.
 // int zmq_send (void *s, zmq_msg_t *msg, int flags);
 func (s *zmqSocket) Send(data []byte, flags SendRecvOption) error {


### PR DESCRIPTION
- zmq_init -> zmq_ctx_new
- zmq_term -> zmq_ctx_destroy
- ZMQ_FAIL_UNROUTABLE -> ZMQ_ROUTER_MANDATORY
- zmq_recvmsg is deprecated in favour of zmq_msg_recv
- zmq_sendmsg is deprecated in favour of zmq_msg_send
- Added constants from zmq.h.
  - Turned var into const where possible.
  - Added missing constants from zmq.h.
- Added some deprecated aliases.
