### PR TITLE
Include ENOTSOCK.

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -118,6 +118,7 @@ type zmqErrno syscall.Errno
 
 var (
 	// Additional ZMQ errors
+	ENOTSOCK       error = zmqErrno(C.ENOTSOCK)
 	EFSM           error = zmqErrno(C.EFSM)
 	ENOCOMPATPROTO error = zmqErrno(C.ENOCOMPATPROTO)
 	ETERM          error = zmqErrno(C.ETERM)


### PR DESCRIPTION
ZeroMQ documentation shows ENOTSOCK defined in 2.1, 2.2, and 3.2, so this shouldn't break any builds.
