### PR TITLE
Support TCP_ACCEPT_FILTER in 3.x

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -50,6 +50,7 @@ type Socket interface {
 	SetSockOptInt64(option Int64SocketOption, value int64) error
 	SetSockOptUInt64(option UInt64SocketOption, value uint64) error
 	SetSockOptString(option StringSocketOption, value string) error
+	SetSockOptStringNil(option StringSocketOption) error
 	GetSockOptInt(option IntSocketOption) (value int, err error)
 	GetSockOptInt64(option Int64SocketOption) (value int64, err error)
 	GetSockOptUInt64(option UInt64SocketOption) (value uint64, err error)
@@ -260,6 +261,15 @@ func (s *zmqSocket) SetSockOptString(option StringSocketOption, value string) er
 	v := C.CString(value)
 	defer C.free(unsafe.Pointer(v))
 	if C.zmq_setsockopt(s.s, C.int(option), unsafe.Pointer(v), C.size_t(len(value))) != 0 {
+		return errno()
+	}
+	return nil
+}
+
+// Set a string option on the socket to nil.
+// int zmq_setsockopt (void *s, int option, const void *optval, size_t optvallen);
+func (s *zmqSocket) SetSockOptStringNil(option StringSocketOption) error {
+	if C.zmq_setsockopt(s.s, C.int(option), nil, 0) != 0 {
 		return errno()
 	}
 	return nil

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -42,8 +42,7 @@ var (
 	TCP_KEEPALIVE_CNT   = IntSocketOption(C.ZMQ_TCP_KEEPALIVE_CNT)
 	TCP_KEEPALIVE_IDLE  = IntSocketOption(C.ZMQ_TCP_KEEPALIVE_IDLE)
 	TCP_KEEPALIVE_INTVL = IntSocketOption(C.ZMQ_TCP_KEEPALIVE_INTVL)
-	// TODO Make this work.
-	//TCP_ACCEPT_FILTER   = IntSocketOption(C.ZMQ_TCP_ACCEPT_FILTER)
+	TCP_ACCEPT_FILTER   = StringSocketOption(C.ZMQ_TCP_ACCEPT_FILTER)
 
 	// Message options
 	MORE = MessageOption(C.ZMQ_MORE)

--- a/zmq_3_x_test.go
+++ b/zmq_3_x_test.go
@@ -50,3 +50,47 @@ func TestProxy(t *testing.T) {
 	te.Recv(out, 0)
 	te.Recv(capture, 0)
 }
+
+func TestSocket_SetSockOptNil(t *testing.T) {
+	failed := make(chan bool, 2)
+	c, _ := NewContext()
+	defer c.Close()
+	go func() {
+		srv, _ := c.NewSocket(REP)
+		defer srv.Close()
+		srv.SetSockOptString(TCP_ACCEPT_FILTER, "127.0.0.1")
+		srv.SetSockOptString(TCP_ACCEPT_FILTER, "192.0.2.1")
+		srv.Bind(ADDRESS1) // 127.0.0.1 and 192.0.2.1 are allowed here.
+		// The test will fail if the following line is removed:
+		srv.SetSockOptNil(TCP_ACCEPT_FILTER)
+		srv.SetSockOptString(TCP_ACCEPT_FILTER, "192.0.2.2")
+		srv.Bind(ADDRESS2) // Only 192.0.2.1 is allowed here.
+		for {
+			if _, err := srv.Recv(0); err != nil {
+				break
+			}
+			srv.Send(nil, 0)
+		}
+	}()
+	go func() {
+		s2, _ := c.NewSocket(REQ)
+		defer s2.Close()
+		s2.SetSockOptInt(LINGER, 0)
+		s2.Connect(ADDRESS2)
+		s2.Send(nil, 0)
+		if _, err := s2.Recv(0); err == nil {
+			// 127.0.0.1 is supposed to be ignored by ADDRESS2:
+			t.Error("SetSockOptNil did not clear TCP_ACCEPT_FILTER.")
+		}
+		failed <- true
+	}()
+	s1, _ := c.NewSocket(REQ)
+	defer s1.Close()
+	s1.Connect(ADDRESS1)
+	s1.Send(nil, 0)
+	s1.Recv(0)
+	select {
+	case <-failed:
+	case <-time.After(50 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
From the commit message for ec1b6dda8e8cbf7663e36546150939925de48a09:

> Since Go will not allow nil where a string is expected, there is no way to change the implementation of existing methods to accept nil strings. This is necessary to properly support e.g. TCP_ACCEPT_FILTER, which can only be cleared by setting it to nil.
