### PR TITLE
Retrieve errno() in a thread-safe way.

### DIFF
--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -43,8 +43,8 @@ func (s *zmqSocket) Send(data []byte, flags SendRecvOption) error {
 	// Copy data array into C-allocated buffer.
 	size := C.size_t(len(data))
 
-	if C.zmq_msg_init_size(&m, size) != 0 {
-		return errno()
+	if rc, err := C.zmq_msg_init_size(&m, size); rc != 0 {
+		return casterr(err)
 	}
 
 	if size > 0 {
@@ -52,10 +52,10 @@ func (s *zmqSocket) Send(data []byte, flags SendRecvOption) error {
 		C.memcpy(unsafe.Pointer(C.zmq_msg_data(&m)), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
 	}
 
-	if C.zmq_send(s.s, &m, C.int(flags)) != 0 {
+	if rc, err := C.zmq_send(s.s, &m, C.int(flags)); rc != 0 {
 		// zmq_send did not take ownership, free message
 		C.zmq_msg_close(&m)
-		return errno()
+		return casterr(err)
 	}
 	return nil
 }
@@ -65,16 +65,18 @@ func (s *zmqSocket) Send(data []byte, flags SendRecvOption) error {
 func (s *zmqSocket) Recv(flags SendRecvOption) (data []byte, err error) {
 	// Allocate and initialise a new zmq_msg_t
 	var m C.zmq_msg_t
-	if C.zmq_msg_init(&m) != 0 {
-		err = errno()
+	var rc C.int
+	if rc, err = C.zmq_msg_init(&m); rc != 0 {
+		err = casterr(err)
 		return
 	}
 	defer C.zmq_msg_close(&m)
 	// Receive into message
-	if C.zmq_recv(s.s, &m, C.int(flags)) != 0 {
-		err = errno()
+	if C.zmq_recv(s.s, &m, C.int(flags)); rc != 0 {
+		err = casterr(err)
 		return
 	}
+	err = nil
 	// Copy message data into a byte array
 	// FIXME Ideally this wouldn't require a copy.
 	size := C.zmq_msg_size(&m)


### PR DESCRIPTION
http://code.google.com/p/go/issues/detail?id=709#c3 shows how errno() can be checked in a thread-safe way with a familiar idiom.

https://zeromq.jira.com/browse/LIBZMQ-338 shows the libzmq devs aren't sure zmq_errno() should be used at all.  The libzmq source as far back as v2.1.0 includes a one-line zmq_errno() implementation that only returns errno, adding nothing to errno().

I'm sure this idea is sound, but of course there may be other ways of implementing the change... for example, maybe we could just use syscall.Errno instead of zmqErrno?
