### PR TITLE
Set NOBLOCK == DONTWAIT.

### DIFF
--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -34,6 +34,9 @@ var (
 	MCAST_LOOP        = Int64SocketOption(C.ZMQ_MCAST_LOOP)
 	HWM               = UInt64SocketOption(C.ZMQ_HWM)
 	NOBLOCK           = SendRecvOption(C.ZMQ_NOBLOCK)
+
+	// Forwards-compatible aliases:
+	DONTWAIT = NOBLOCK
 )
 
 // Send a message to the socket.

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -49,6 +49,9 @@ var (
 
 	// Send/recv options
 	DONTWAIT = SendRecvOption(C.ZMQ_DONTWAIT)
+
+	// Deprecated aliases
+	NOBLOCK = DONTWAIT
 )
 
 // Send a message to the socket.


### PR DESCRIPTION
I'm not sure whether its better to include backwards-compatible aliases in 3.x or forwards-compatible aliases in 2.x, so I've added both.  Does anybody have an opinion about this?
