### PR TITLE
Change var to const where possible

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -72,7 +72,7 @@ type BoolSocketOption int
 type MessageOption int
 type SendRecvOption int
 
-var (
+const (
 	// NewSocket types
 	PAIR   = SocketType(C.ZMQ_PAIR)
 	PUB    = SocketType(C.ZMQ_PUB)
@@ -127,7 +127,7 @@ var (
 
 type PollEvents C.short
 
-var (
+const (
 	POLLIN  = PollEvents(C.ZMQ_POLLIN)
 	POLLOUT = PollEvents(C.ZMQ_POLLOUT)
 	POLLERR = PollEvents(C.ZMQ_POLLERR)
@@ -135,7 +135,7 @@ var (
 
 type DeviceType int
 
-var (
+const (
 	STREAMER  = DeviceType(C.ZMQ_STREAMER)
 	FORWARDER = DeviceType(C.ZMQ_FORWARDER)
 	QUEUE     = DeviceType(C.ZMQ_QUEUE)

--- a/zmq_2_2.go
+++ b/zmq_2_2.go
@@ -23,7 +23,7 @@ package gozmq
 */
 import "C"
 
-var (
+const (
 	RCVTIMEO = IntSocketOption(C.ZMQ_RCVTIMEO)
 	SNDTIMEO = IntSocketOption(C.ZMQ_SNDTIMEO)
 )

--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -28,7 +28,7 @@ package gozmq
 import "C"
 import "unsafe"
 
-var (
+const (
 	RECOVERY_IVL_MSEC = Int64SocketOption(C.ZMQ_RECOVERY_IVL_MSEC)
 	SWAP              = Int64SocketOption(C.ZMQ_SWAP)
 	MCAST_LOOP        = Int64SocketOption(C.ZMQ_MCAST_LOOP)

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -31,7 +31,7 @@ import (
 	"unsafe"
 )
 
-var (
+const (
 	SNDHWM = IntSocketOption(C.ZMQ_SNDHWM)
 	RCVHWM = IntSocketOption(C.ZMQ_SNDHWM)
 


### PR DESCRIPTION
This changes var to const almost everywhere except in the list of zmqErrno, which can be const too if we make zmqErrno a public type...
