### PR TITLE
Fix Errno Comparison

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -171,10 +171,18 @@ func (e zmqErrno) Error() string {
 // If possible, convert a syscall.Errno to a zmqErrno.
 func casterr(fromcgo error) error {
 	errno, ok := fromcgo.(syscall.Errno)
-	if ok && errno >= C.ZMQ_HAUSNUMERO {
-		return zmqErrno(errno)
+	if !ok {
+		return fromcgo
 	}
-	return fromcgo
+	zmqerrno := zmqErrno(errno)
+	switch zmqerrno {
+	case ENOTSOCK:
+		return zmqerrno
+	}
+	if zmqerrno >= C.ZMQ_HAUSNUMERO {
+		return zmqerrno
+	}
+	return errno
 }
 
 func getErrorForTesting() error {


### PR DESCRIPTION
My work on #51 caused this bug, and of the constants defined it only affected ENOTSOCK.  Maybe the test is overzealous, but writing it helped me to clear up some of my ideas about error checking in Go.
