### PR TITLE
fix SetSockOptInt on 64-bit platforms for 1.1

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -230,7 +230,8 @@ func (s *Socket) Close() error {
 // Set an int option on the socket.
 // int zmq_setsockopt (void *s, int option, const void *optval, size_t optvallen);
 func (s *Socket) SetSockOptInt(option IntSocketOption, value int) error {
-	if rc, err := C.zmq_setsockopt(s.s, C.int(option), unsafe.Pointer(&value), C.size_t(unsafe.Sizeof(value))); rc != 0 {
+	val := C.int(value)
+	if rc, err := C.zmq_setsockopt(s.s, C.int(option), unsafe.Pointer(&val), C.size_t(unsafe.Sizeof(val))); rc != 0 {
 		return casterr(err)
 	}
 	return nil

--- a/zmq_test.go
+++ b/zmq_test.go
@@ -27,7 +27,7 @@ const ADDRESS1 = "tcp://127.0.0.1:23456"
 const ADDRESS2 = "tcp://127.0.0.1:23457"
 const ADDRESS3 = "tcp://127.0.0.1:23458"
 
-// Addresses for the device test. These cannot be reused since the device 
+// Addresses for the device test. These cannot be reused since the device
 // will keep running after the test terminates
 const ADDR_DEV_IN = "tcp://127.0.0.1:24111"
 const ADDR_DEV_OUT = "tcp://127.0.0.1:24112"
@@ -179,6 +179,22 @@ func TestBindToLoopBack(t *testing.T) {
 	}
 }
 
+func TestSetSockOptInt(t *testing.T) {
+	c, _ := NewContext()
+	defer c.Close()
+	s, _ := c.NewSocket(REQ)
+	defer s.Close()
+	var linger int = 42
+	if rc := s.SetSockOptInt(LINGER, linger); rc != nil {
+		t.Errorf("Failed to set linger; %v", rc)
+	}
+	if val, rc := s.GetSockOptInt(LINGER); rc != nil {
+		t.Errorf("Failed to unsubscribe; %v", rc)
+	} else if val != linger {
+		t.Errorf("Expected %d, got %d", linger, val)
+	}
+}
+
 func TestSetSockOptString(t *testing.T) {
 	c, _ := NewContext()
 	defer c.Close()
@@ -311,7 +327,7 @@ func TestMessageMemory(t *testing.T) {
 
 func doBenchmarkSendReceive(b *testing.B, size int, addr string) {
 	// since this is a benchmark it should probably call
-	// this package's api functions directly rather than 
+	// this package's api functions directly rather than
 	// using the testEnv wrappers
 	b.StopTimer()
 	data := make([]byte, size)

--- a/zmq_test.go
+++ b/zmq_test.go
@@ -189,7 +189,7 @@ func TestSetSockOptInt(t *testing.T) {
 		t.Errorf("Failed to set linger; %v", rc)
 	}
 	if val, rc := s.GetSockOptInt(LINGER); rc != nil {
-		t.Errorf("Failed to unsubscribe; %v", rc)
+		t.Errorf("Failed to get linger; %v", rc)
 	} else if val != linger {
 		t.Errorf("Expected %d, got %d", linger, val)
 	}


### PR DESCRIPTION
Value now is converted to C.int precisely due to Go 1.1 will make int and uint 64 bits on 64-bit platforms. And this patch should be backward compatible as I've tested in both 1.0.3 and 1.1rc2.
