### PR TITLE
Add basic support for zmq_socket_monitor

### DIFF
--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -54,6 +54,30 @@ const (
 	NOBLOCK = DONTWAIT
 )
 
+// Socket transport events
+type Event int
+
+const (
+	EVENT_CONNECTED       = Event(C.ZMQ_EVENT_CONNECTED)
+	EVENT_CONNECT_DELAYED = Event(C.ZMQ_EVENT_CONNECT_DELAYED)
+	EVENT_CONNECT_RETRIED = Event(C.ZMQ_EVENT_CONNECT_RETRIED)
+
+	EVENT_LISTENING   = Event(C.ZMQ_EVENT_LISTENING)
+	EVENT_BIND_FAILED = Event(C.ZMQ_EVENT_BIND_FAILED)
+
+	EVENT_ACCEPTED      = Event(C.ZMQ_EVENT_ACCEPTED)
+	EVENT_ACCEPT_FAILED = Event(C.ZMQ_EVENT_ACCEPT_FAILED)
+
+	EVENT_CLOSED       = Event(C.ZMQ_EVENT_CLOSED)
+	EVENT_CLOSE_FAILED = Event(C.ZMQ_EVENT_CLOSE_FAILED)
+	EVENT_DISCONNECTED = Event(C.ZMQ_EVENT_DISCONNECTED)
+
+	EVENT_ALL = EVENT_CONNECTED | EVENT_CONNECT_DELAYED |
+		EVENT_CONNECT_RETRIED | EVENT_LISTENING | EVENT_BIND_FAILED |
+		EVENT_ACCEPTED | EVENT_ACCEPT_FAILED | EVENT_CLOSED |
+		EVENT_CLOSE_FAILED | EVENT_DISCONNECTED
+)
+
 // Get a context option.
 // int zmq_ctx_get (void *c, int);
 func (c *Context) get(option C.int) (int, error) {
@@ -156,6 +180,19 @@ func (s *Socket) Recv(flags SendRecvOption) (data []byte, err error) {
 		data = nil
 	}
 	return
+}
+
+// Register a monitoring callback endpoint.
+// int zmq_socket_monitor (void *s, const char *addr, int events);
+func (s *Socket) Monitor(address string, events Event) error {
+	a := C.CString(address)
+	defer C.free(unsafe.Pointer(a))
+
+	rc, err := C.zmq_socket_monitor(s.apiSocket(), a, C.int(events))
+	if rc == -1 {
+		return casterr(err)
+	}
+	return nil
 }
 
 // Portability helper

--- a/zmq_3_x_test.go
+++ b/zmq_3_x_test.go
@@ -200,4 +200,6 @@ func waitForEvent(t *testing.T, monitor *Socket) error {
 	case <-timeout:
 		return errors.New("Test timed out")
 	}
+
+	return nil
 }

--- a/zmq_3_x_test.go
+++ b/zmq_3_x_test.go
@@ -18,6 +18,7 @@
 package gozmq
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -122,5 +123,81 @@ func TestSocket_SetSockOptStringNil(t *testing.T) {
 	select {
 	case <-failed:
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+const (
+	TESTMONITOR_ADDR_SINK   = "tcp://127.0.0.1:24117"
+	TESTMONITOR_ADDR_EVENTS = "inproc://TestMonitorEvents"
+)
+
+func TestMonitor(t *testing.T) {
+	te := NewTestEnv(t)
+	defer te.Close()
+
+	// Prepare the sink socket.
+	out := te.NewSocket(PULL)
+	err := out.Bind(TESTMONITOR_ADDR_SINK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepare the source socket, do not connect yet.
+	in := te.NewSocket(PUSH)
+	defer in.Close()
+
+	// Attach the monitor.
+	err = in.Monitor(TESTMONITOR_ADDR_EVENTS,
+		EVENT_CONNECTED|EVENT_DISCONNECTED)
+	if err != nil {
+		out.Close()
+		t.Fatal(err)
+	}
+
+	monitor := te.NewConnectedSocket(PAIR, TESTMONITOR_ADDR_EVENTS)
+
+	// Connect the client to the server, wait for EVENT_CONNECTED.
+	err = in.Connect(TESTMONITOR_ADDR_SINK)
+	if err != nil {
+		out.Close()
+		t.Fatal(err)
+	}
+
+	err = waitForEvent(t, monitor)
+	if err != nil {
+		out.Close()
+		t.Fatal(err)
+	}
+
+	// Close the sink socket, wait for EVENT_DISCONNECTED.
+	err = out.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = waitForEvent(t, monitor)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForEvent(t *testing.T, monitor *Socket) error {
+	exit := make(chan error, 1)
+
+	// This goroutine will return either when an event is received
+	// or the context is closed.
+	go func() {
+		// RecvMultipart should work for both zeromq3-x and libzmq API.
+		_, ex := monitor.RecvMultipart(0)
+		exit <- ex
+	}()
+
+	timeout := time.After(time.Second)
+
+	select {
+	case err := <-exit:
+		return err
+	case <-timeout:
+		return errors.New("Test timed out")
 	}
 }

--- a/zmq_test.go
+++ b/zmq_test.go
@@ -422,7 +422,6 @@ func (te *testEnv) pushSocket(s *Socket) {
 }
 
 func (te *testEnv) Close() {
-
 	if err := recover(); err != nil {
 		te.t.Errorf("failed in testEnv: %v", err)
 	}


### PR DESCRIPTION
Hi,

Following the small discussion with @jtacoma at #75, I was thinking that we could start implementing zmq_socket_monitor, or at least discuss how to do it.

The API call itself is pretty simple and is already present in the pull request (no tests for now). Now the question is how to work with this whole monitor thing further. I discovered that in fact there are 2 distinct version of the `zmq_event_t` (i.e. 2 versions of the monitor API). The old (deprecated as of now I think) version is still in the [zeromq3-x](https://github.com/zeromq/zeromq3-x/blob/master/include/zmq.h#L293) repository while the new one is in [libzmq](https://github.com/zeromq/libzmq/blob/master/include/zmq.h#L322) itself. Now the question is what we want to support. Can we drop zeromq3-x?

Anyway, I think that the new API would be much easier to support, because then you can use gozmq Recv to receive events, which is not that simple with the old API since you are passing C structs around. So I guess that would require a special call for receiving events in that case...

What do you think?
