### PR TITLE
Use C.GoBytes instead of C.memcpy

### DIFF
--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -63,7 +63,7 @@ func (s *Socket) Send(data []byte, flags SendRecvOption) error {
 
 	if size > 0 {
 		// FIXME Ideally this wouldn't require a copy.
-		C.memcpy(unsafe.Pointer(C.zmq_msg_data(&m)), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
+		C.memcpy(C.zmq_msg_data(&m), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
 	}
 
 	if rc, err := C.zmq_send(s.s, &m, C.int(flags)); rc != 0 {
@@ -95,8 +95,7 @@ func (s *Socket) Recv(flags SendRecvOption) (data []byte, err error) {
 	// FIXME Ideally this wouldn't require a copy.
 	size := C.zmq_msg_size(&m)
 	if size > 0 {
-		data = make([]byte, int(size))
-		C.memcpy(unsafe.Pointer(&data[0]), C.zmq_msg_data(&m), size)
+		data = C.GoBytes(C.zmq_msg_data(&m), C.int(size))
 	} else {
 		data = nil
 	}

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -142,7 +142,7 @@ func (s *Socket) Send(data []byte, flags SendRecvOption) error {
 
 	if size > 0 {
 		// FIXME Ideally this wouldn't require a copy.
-		C.memcpy(unsafe.Pointer(C.zmq_msg_data(&m)), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
+		C.memcpy(C.zmq_msg_data(&m), unsafe.Pointer(&data[0]), size) // XXX I hope this works...(seems to)
 	}
 
 	if rc, err := C.zmq_sendmsg(s.s, &m, C.int(flags)); rc == -1 {
@@ -174,8 +174,7 @@ func (s *Socket) Recv(flags SendRecvOption) (data []byte, err error) {
 	// FIXME Ideally this wouldn't require a copy.
 	size := C.zmq_msg_size(&m)
 	if size > 0 {
-		data = make([]byte, int(size))
-		C.memcpy(unsafe.Pointer(&data[0]), C.zmq_msg_data(&m), size)
+		data = C.GoBytes(C.zmq_msg_data(&m), C.int(size))
 	} else {
 		data = nil
 	}


### PR DESCRIPTION
I noticed that there was memcpy used a few times where C.GoBytes was more
appropriate.

Also remoted a few unnecessary unsafe.Pointer casts.

Signed-off-by: Ondrej Kupka ondra.cap@gmail.com
