### PR TITLE
Add simple zero copy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The API implemented by this package does not attempt to expose
 `zmq_msg_t` at all. Instead, `Recv()` and `Send()` both operate on byte
 slices, allocating and freeing the memory automatically. Currently this
 requires copying to/from C malloced memory, but a future implementation
-may be able to avoid this to a certain extent.
+may be able to avoid this to a certain extent. `SendZeroCopy()` is the first
+step in this direction.
 
 All major features are supported: contexts, sockets, devices, and polls.
 
@@ -125,16 +126,6 @@ func main() {
 ```
 
 ## Caveats
-
-### Zero-copy
-
-GoZMQ does not support zero-copy.
-
-GoZMQ does not attempt to expose `zmq_msg_t` at all. Instead, `Recv()` and `Send()`
-both operate on byte slices, allocating and freeing the memory automatically.
-Currently this requires copying to/from C malloced memory, but a future
-implementation may be able to avoid this to a certain extent.
-
 
 ### Memory management
 

--- a/zc.c
+++ b/zc.c
@@ -1,0 +1,45 @@
+/*
+  Copyright 2013 Ondrej Kupka
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <stdlib.h>
+#include <zmq.h>
+
+extern int gozmq_zc_seq();
+extern void gozmq_zc_free_msg(int seq);
+
+static void free_msg_wrap(void *data, void *hint);
+
+int
+gozmq_zc_send(void *socket, void *data, size_t size, int flags)
+{
+	zmq_msg_t msg;
+
+	int *seq = malloc(sizeof(int));
+	*seq = gozmq_zc_seq();
+
+	zmq_msg_init_data(&msg, data, size, free_msg_wrap, seq);
+
+	if (zmq_sendmsg(socket, &msg, flags) == -1)
+		return -1;
+	return 0;
+}
+
+static void
+free_msg_wrap(void *data, void *hint)
+{
+	gozmq_zc_free_msg(*(int*)hint);
+	free(hint);
+}

--- a/zc.c
+++ b/zc.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <zmq.h>
 
-extern int gozmq_zc_seq();
+extern int  gozmq_zc_seq();
 extern void gozmq_zc_free_msg(int seq);
 
 static void free_msg_wrap(void *data, void *hint);
@@ -32,8 +32,16 @@ gozmq_zc_send(void *socket, void *data, size_t size, int flags)
 
 	zmq_msg_init_data(&msg, data, size, free_msg_wrap, seq);
 
+#if ZMQ_VERSION_MAJOR == 3
 	if (zmq_sendmsg(socket, &msg, flags) == -1)
 		return -1;
+#elif ZMQ_VERSION_MAJOR == 2
+	if (zmq_send(socket, &msg, flags) == -1)
+		return -1;
+#else
+#error Only libzmq 2.x and 3.x is supported.
+#endif
+
 	return 0;
 }
 

--- a/zc.c
+++ b/zc.c
@@ -28,7 +28,7 @@ gozmq_zc_sendmsg(void *socket, void *data, size_t dlen, int flags, void *hint)
 		return -1;
 
 #if ZMQ_VERSION_MAJOR == 3
-	if (zmq_sendmsg(socket, &msg, flags) == -1)
+	if (zmq_msg_send(&msg, socket, flags) == -1)
 		return -1;
 #elif ZMQ_VERSION_MAJOR == 2
 	if (zmq_send(socket, &msg, flags) == -1)

--- a/zc.c
+++ b/zc.c
@@ -23,14 +23,14 @@ extern void gozmq_zc_free_msg(int seq);
 static void free_msg_wrap(void *data, void *hint);
 
 int
-gozmq_zc_send(void *socket, void *data, size_t size, int flags)
+gozmq_zc_send(void *socket, void *data, size_t size, int flags, int seq)
 {
 	zmq_msg_t msg;
 
-	int *seq = malloc(sizeof(int));
-	*seq = gozmq_zc_seq();
+	int *hint = malloc(sizeof(seq));
+	*hint = seq;
 
-	zmq_msg_init_data(&msg, data, size, free_msg_wrap, seq);
+	zmq_msg_init_data(&msg, data, size, free_msg_wrap, hint);
 
 #if ZMQ_VERSION_MAJOR == 3
 	if (zmq_sendmsg(socket, &msg, flags) == -1)

--- a/zc.h
+++ b/zc.h
@@ -17,6 +17,7 @@
 #ifndef GOZMQ_ZC_H
 #define GOZMQ_ZC_H
 
-int gozmq_zc_send(void *socket, void *data, size_t size, int flags, int seq);
+int gozmq_zc_sendmsg(void *socket, void *data, size_t datalen,
+		int flags, void *hint);
 
 #endif

--- a/zc.h
+++ b/zc.h
@@ -1,0 +1,22 @@
+/*
+  Copyright 2013 Ondrej Kupka
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifndef GOZMQ_ZC_H
+#define GOZMQ_ZC_H
+
+int gozmq_zc_send(void *socket, void *data, size_t size, int flags);
+
+#endif

--- a/zc.h
+++ b/zc.h
@@ -17,6 +17,6 @@
 #ifndef GOZMQ_ZC_H
 #define GOZMQ_ZC_H
 
-int gozmq_zc_send(void *socket, void *data, size_t size, int flags);
+int gozmq_zc_send(void *socket, void *data, size_t size, int flags, int seq);
 
 #endif

--- a/zmq.go
+++ b/zmq.go
@@ -539,5 +539,3 @@ func (r *ZCFrameRegister) Remove(data, hint unsafe.Pointer) {
 // void *zmq_msg_data (zmq_msg_t *msg);
 // int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
 // int zmq_msg_move (zmq_msg_t *dest, zmq_msg_t *src);
-
-

--- a/zmq_3_x.go
+++ b/zmq_3_x.go
@@ -23,10 +23,12 @@ package gozmq
 #include <zmq.h>
 #include <stdlib.h>
 #include <string.h>
+#include "zc.h"
 */
 import "C"
 import (
 	"errors"
+	"sync"
 	"unsafe"
 )
 
@@ -151,6 +153,41 @@ func (s *Socket) Send(data []byte, flags SendRecvOption) error {
 		return casterr(err)
 	}
 	return nil
+}
+
+// Send a message to the socket using 0MQ zero copy.
+// ZeroCopySend is suitable only for large messages since it (for now)
+// incorporates some synchronization overhead in its Go part.
+func (s *Socket) ZeroCopySend(data []byte, flags SendRecvOption) error {
+	rc, err := C.gozmq_zc_send(s.apiSocket(),
+		unsafe.Pointer(&data[0]), C.size_t(len(data)), C.int(flags))
+	if rc == -1 {
+		return casterr(err)
+	}
+	return nil
+}
+
+var (
+	zcSeq  int
+	zcData map[int][]byte = make(map[int][]byte)
+	zcLock sync.Mutex
+)
+
+//export gozmq_zc_seq
+func gozmq_zc_seq() C.int {
+	zcLock.Lock()
+	defer zcLock.Unlock()
+
+	zcSeq++
+	return C.int(zcSeq)
+}
+
+//export gozmq_zc_free_msg
+func gozmq_zc_free_msg(seq C.int) {
+	zcLock.Lock()
+	defer zcLock.Unlock()
+
+	delete(zcData, int(seq))
 }
 
 // Receive a message from the socket.

--- a/zmq_test.go
+++ b/zmq_test.go
@@ -16,12 +16,12 @@
 package gozmq
 
 import (
+	"crypto/rand"
 	"log"
 	"runtime"
 	"syscall"
 	"testing"
 	"time"
-	"crypto/rand"
 )
 
 const ADDRESS1 = "tcp://127.0.0.1:23456"
@@ -481,19 +481,19 @@ func BenchmarkSendReceive1MBinprocZC(b *testing.B) {
 }
 
 func BenchmarkSendReceive10MBinproc(b *testing.B) {
-	doBenchmarkSendReceive(b, 10 * 1e6, ADDRESS_INPROC)
+	doBenchmarkSendReceive(b, 10*1e6, ADDRESS_INPROC)
 }
 
 func BenchmarkSendReceive10MBinprocZC(b *testing.B) {
-	doBenchmarkSendReceiveZC(b, 10 * 1e6, ADDRESS_INPROC)
+	doBenchmarkSendReceiveZC(b, 10*1e6, ADDRESS_INPROC)
 }
 
 func BenchmarkSendReceive100MBinproc(b *testing.B) {
-	doBenchmarkSendReceive(b, 100 * 1e6, ADDRESS_INPROC)
+	doBenchmarkSendReceive(b, 100*1e6, ADDRESS_INPROC)
 }
 
 func BenchmarkSendReceive100MBinprocZC(b *testing.B) {
-	doBenchmarkSendReceiveZC(b, 100 * 1e6, ADDRESS_INPROC)
+	doBenchmarkSendReceiveZC(b, 100*1e6, ADDRESS_INPROC)
 }
 
 // A helper to make tests less verbose


### PR DESCRIPTION
The simplest thing I managed to come up with is to simply remember the data still being used in a map in the Go part so that it's not GC'd. In the callback it's then enough to just delete the record in the map and we are done. Unfortunately there is some synchronization needed, creating a possible bottleneck, but who knows, maybe not. And it's locking in the callback, so I don't know what scenario would really break this down. It should be fine and enough.

As an improvement it could be possible to simply pass the key as the integer, i.e. don't malloc space for the integer and pass the pointer, but simply cast the integer to pointer and pass that one...

I also don't like the global state in the Go module, I will think about it a bit more, if it is possible to get rid of that. I don't think that you can possibly manage to fill the map with ID's even if you use several contexts, but it's just ugly...

Btw tests and other stuff left out for now, we should first get this into a usable state and then take care of the rest I think.

In fact I haven't even tried to run it, just to compile it :P

Signed-off-by: Ondrej Kupka ondra.cap@gmail.com
