### PR TITLE
Travis CI: Use current version of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 before_install:
 - sudo apt-get install libzmq3-dev
 language: go
+go: 1.1.1
 install: go get -tags zmq_3_x -d -v ./... && go build -tags zmq_3_x -v ./...
 script: go test -v -tags zmq_3_x ./...


### PR DESCRIPTION
Update Travis CI config file to use some new cool features introduced in Go 1.1.

Not sure how much backwards compatible we need to be, but this would be useful... Particularly because it would be useful for my zero copy pull request :DDD

Signed-off-by: Ondrej Kupka ondra.cap@gmail.com
