### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/zmq.go
+++ b/zmq.go
@@ -275,7 +275,7 @@ func (s *Socket) SetSockOptStringNil(option StringSocketOption) error {
 	return nil
 }
 
-// Get an int option from the socket.
+// GetSockOptInt gets an int option from the socket.
 // int zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
 func (s *Socket) GetSockOptInt(option IntSocketOption) (value int, err error) {
 	size := C.size_t(unsafe.Sizeof(value))
@@ -287,7 +287,7 @@ func (s *Socket) GetSockOptInt(option IntSocketOption) (value int, err error) {
 	return
 }
 
-// Get an int64 option from the socket.
+// GetSockOptInt64 gets an int64 option from the socket.
 // int zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
 func (s *Socket) GetSockOptInt64(option Int64SocketOption) (value int64, err error) {
 	size := C.size_t(unsafe.Sizeof(value))
@@ -299,7 +299,7 @@ func (s *Socket) GetSockOptInt64(option Int64SocketOption) (value int64, err err
 	return
 }
 
-// Get a uint64 option from the socket.
+// GetSockOptUInt64 gets a uint64 option from the socket.
 // int zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
 func (s *Socket) GetSockOptUInt64(option UInt64SocketOption) (value uint64, err error) {
 	size := C.size_t(unsafe.Sizeof(value))
@@ -312,7 +312,7 @@ func (s *Socket) GetSockOptUInt64(option UInt64SocketOption) (value uint64, err 
 	return
 }
 
-// Get a string option from the socket.
+// GetSockOptString gets a string option from the socket.
 // int zmq_getsockopt (void *s, int option, void *optval, size_t *optvallen);
 func (s *Socket) GetSockOptString(option StringSocketOption) (value string, err error) {
 	var buffer [1024]byte

--- a/zmq_2_x.go
+++ b/zmq_2_x.go
@@ -39,7 +39,7 @@ const (
 	DONTWAIT = NOBLOCK
 )
 
-// Get a context option.
+// IOThreads gets a context option.
 func (c *Context) IOThreads() (int, error) {
 	return c.iothreads, nil
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._